### PR TITLE
Release 1.2.2  - PPM-4

### DIFF
--- a/Api/Data/PaymentStatusHistoryInterface.php
+++ b/Api/Data/PaymentStatusHistoryInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Api\Data;
+
+interface PaymentStatusHistoryInterface
+{
+
+    const ORDER_ID    = 'order_id';
+    const STATUS      = 'status';
+    const ENTITY_ID   = 'entity_id';
+    const EXTERNAL_ID = 'external_id';
+    const CREATED_AT     = 'created_at';
+    const PAYMENT_ID  = 'payment_id';
+
+    /**
+     * Get entity_id
+     *
+     * @return string|null
+     */
+    public function getId();
+
+    /**
+     * Set entity_id
+     *
+     * @param string $id
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setId($id);
+
+    /**
+     * Get payment_id
+     *
+     * @return string|null
+     */
+    public function getPaymentId();
+
+    /**
+     * Set payment_id
+     *
+     * @param string $paymentId
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setPaymentId($paymentId);
+
+    /**
+     * Get external_id
+     *
+     * @return string|null
+     */
+    public function getExternalId();
+
+    /**
+     * Set external_id
+     *
+     * @param string $externalId
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setExternalId($externalId);
+
+    /**
+     * Get status
+     *
+     * @return string|null
+     */
+    public function getStatus();
+
+    /**
+     * Set status
+     *
+     * @param string $status
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setStatus($status);
+
+    /**
+     * Get created_at
+     *
+     * @return string|null
+     */
+    public function getCreatedAt();
+
+    /**
+     * Set created_at
+     *
+     * @param string $createdAt
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setCreatedAt($createdAt);
+
+    /**
+     * Get order_id
+     *
+     * @return string|null
+     */
+    public function getOrderId();
+
+    /**
+     * Set order_id
+     *
+     * @param string $orderId
+     * @return \Paynow\PaymentGateway\PaymentStatusHistory\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function setOrderId($orderId);
+}
+

--- a/Api/Data/PaymentStatusHistoryInterface.php
+++ b/Api/Data/PaymentStatusHistoryInterface.php
@@ -11,7 +11,7 @@ interface PaymentStatusHistoryInterface
     const STATUS      = 'status';
     const ENTITY_ID   = 'entity_id';
     const EXTERNAL_ID = 'external_id';
-    const CREATED_AT     = 'created_at';
+    const CREATED_AT  = 'created_at';
     const PAYMENT_ID  = 'payment_id';
 
     /**

--- a/Api/Data/PaymentStatusHistorySearchResultsInterface.php
+++ b/Api/Data/PaymentStatusHistorySearchResultsInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Api\Data;
+
+interface PaymentStatusHistorySearchResultsInterface extends \Magento\Framework\Api\SearchResultsInterface
+{
+
+    /**
+     * Get PaymentStatusHistory list.
+     *
+     * @return \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface[]
+     */
+    public function getItems();
+
+    /**
+     * Set payment_id list.
+     *
+     * @param \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface[] $items
+     * @return $this
+     */
+    public function setItems(array $items);
+}
+

--- a/Api/PaymentStatusHistoryRepositoryInterface.php
+++ b/Api/PaymentStatusHistoryRepositoryInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+interface PaymentStatusHistoryRepositoryInterface
+{
+
+    /**
+     * Save PaymentStatusHistory
+     *
+     * @param \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface $PaymentStatusHistory
+     * @return \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function save(
+        \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface $PaymentStatusHistory
+    );
+
+    /**
+     * Retrieve PaymentStatusHistory
+     *
+     * @param string $id
+     * @return \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function get($id);
+
+    /**
+     * Retrieve PaymentStatusHistory matching the specified criteria.
+     *
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Paynow\PaymentGateway\Api\Data\PaymentStatusHistorySearchResultsInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getList(
+        \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+    );
+
+    /**
+     * Delete PaymentStatusHistory
+     *
+     * @param \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface $PaymentStatusHistory
+     * @return bool true on success
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function delete(
+        \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface $PaymentStatusHistory
+    );
+
+    /**
+     * Delete PaymentStatusHistory by ID
+     *
+     * @param string $id
+     * @return bool true on success
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function deleteById($id);
+
+    /**
+     *  Retrieve last PaymentStatusHistory by externalId and  paymentId
+     *
+     * @param $externalId
+     * @param $paymentId
+     * @return \Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface
+     */
+    public function getLastByExternalIdAndPaymentId($externalId, $paymentId);
+
+}
+
+

--- a/Block/Adminhtml/System/Config/Comment/StoredKeyMasker.php
+++ b/Block/Adminhtml/System/Config/Comment/StoredKeyMasker.php
@@ -35,7 +35,7 @@ class StoredKeyMasker implements CommentInterface
      */
     public function getCommentText($elementValue)
     {
-        $apiKeyStored = substr($this->encryptor->decrypt(trim($elementValue)), -6);
+        $apiKeyStored = substr($this->encryptor->decrypt(trim($elementValue ?? '')), -6);
         if (!$apiKeyStored) {
             return '';
         }

--- a/Controller/Payment/Notifications.php
+++ b/Controller/Payment/Notifications.php
@@ -90,7 +90,9 @@ class Notifications extends Action
     {
         $payload          = $this->getRequest()->getContent();
         $notificationData = json_decode($payload, true);
-        $this->logger->debug("Received payment status notification", $notificationData);
+        if (!is_null($notificationData)){
+            $this->logger->debug("Received payment status notification", $notificationData);
+        }
         $storeId      = $this->storeManager->getStore()->getId();
         $signatureKey = $this->configHelper->getSignatureKey($storeId, $this->configHelper->isTestMode($storeId));
 

--- a/Controller/Payment/Notifications.php
+++ b/Controller/Payment/Notifications.php
@@ -90,9 +90,7 @@ class Notifications extends Action
     {
         $payload          = $this->getRequest()->getContent();
         $notificationData = json_decode($payload, true);
-        if (!is_null($notificationData)){
-            $this->logger->debug("Received payment status notification", $notificationData);
-        }
+        $this->logger->debug("Received payment status notification", $notificationData);
         $storeId      = $this->storeManager->getStore()->getId();
         $signatureKey = $this->configHelper->getSignatureKey($storeId, $this->configHelper->isTestMode($storeId));
 

--- a/Helper/NotificationProcessor.php
+++ b/Helper/NotificationProcessor.php
@@ -329,10 +329,7 @@ class NotificationProcessor
                 Status::STATUS_ABANDONED
             ],
             Status::STATUS_REJECTED  => [
-                Status::STATUS_PENDING,
-                Status::STATUS_CONFIRMED,
-                Status::STATUS_ABANDONED,
-                Status::STATUS_NEW
+                Status::STATUS_ABANDONED
             ],
             Status::STATUS_CONFIRMED => [],
             Status::STATUS_ERROR     => [
@@ -346,7 +343,13 @@ class NotificationProcessor
         ];
 
         if ($paymentIdStrict == false) {
-            $paymentStatusFlow[Status::STATUS_ABANDONED] = [Status::STATUS_NEW];
+            array_push(
+                $paymentStatusFlow[Status::STATUS_REJECTED],
+                Status::STATUS_NEW,
+                Status::STATUS_PENDING,
+                Status::STATUS_CONFIRMED
+            );
+            $paymentStatusFlow[Status::STATUS_ABANDONED][] = Status::STATUS_NEW;
         }
 
         $previousStatusExists = isset($paymentStatusFlow[$previousStatus]);

--- a/Helper/NotificationProcessor.php
+++ b/Helper/NotificationProcessor.php
@@ -156,13 +156,16 @@ class NotificationProcessor
                 $this->paymentAbandoned();
                 break;
         }
+
         /** @var PaymentStatusHistory $paymentStatusHistory */
         $paymentStatusHistory = $this->paymentStatusHistoryFactory->create();
-        $paymentStatusHistory->setOrderId($this->order->getId());
-        $paymentStatusHistory->setExternalId($externalId);
-        $paymentStatusHistory->setPaymentId($paymentId);
-        $paymentStatusHistory->setStatus($status);
+        $paymentStatusHistory
+            ->setOrderId($this->order->getId())
+            ->setExternalId($externalId)
+            ->setPaymentId($paymentId)
+            ->setStatus($status);
         $this->paymentStatusHistoryRepository->save($paymentStatusHistory);
+
         $this->orderRepository->save($this->order);
     }
 

--- a/Helper/NotificationProcessor.php
+++ b/Helper/NotificationProcessor.php
@@ -10,6 +10,7 @@ use Paynow\Model\Payment\Status;
 use Paynow\PaymentGateway\Model\Exception\OrderHasBeenAlreadyPaidException;
 use Paynow\PaymentGateway\Model\Exception\OrderNotFound;
 use Paynow\PaymentGateway\Model\Exception\OrderPaymentStatusTransitionException;
+use Paynow\PaymentGateway\Model\Exception\OrderPaymentStrictStatusTransitionException;
 use Paynow\PaymentGateway\Model\Logger\Logger;
 use Paynow\PaymentGateway\Model\PaymentStatusHistory;
 use Paynow\PaymentGateway\Model\PaymentStatusHistoryFactory;
@@ -85,6 +86,7 @@ class NotificationProcessor
      * @throws OrderNotFound
      * @throws OrderHasBeenAlreadyPaidException
      * @throws OrderPaymentStatusTransitionException
+     * @throws OrderPaymentStrictStatusTransitionException
      */
     public function process($paymentId, $status, $externalId)
     {
@@ -99,9 +101,10 @@ class NotificationProcessor
         );
         if ($lastPaymentOrder->getId()) {
             if (!$this->isCorrectStatus($lastPaymentOrder->getStatus(), $status, true)) {
-                throw new OrderPaymentStatusTransitionException(
+                throw new OrderPaymentStrictStatusTransitionException(
                     $lastPaymentOrder->getStatus(),
-                    $status
+                    $status,
+                    $paymentId
                 );
             }
         }
@@ -339,6 +342,7 @@ class NotificationProcessor
                 Status::STATUS_NEW
             ],
             Status::STATUS_EXPIRED   => [],
+            Status::STATUS_ABANDONED => [],
         ];
 
         if ($paymentIdStrict == false) {

--- a/Model/Exception/OrderPaymentStrictStatusTransitionException.php
+++ b/Model/Exception/OrderPaymentStrictStatusTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Paynow\PaymentGateway\Model\Exception;
+
+use Exception;
+
+/**
+ * Class OrderPaymentStrictStatusTransitionException
+ *
+ * @package Paynow\PaymentGateway\Model\Exception
+ */
+class OrderPaymentStrictStatusTransitionException extends Exception
+{
+    const EXCEPTION_MESSAGE = 'Order status transition from %s to %s is incorrect - strict to paymentId %s';
+
+    public function __construct($orderPaymentStatus, $paymentStatus, $paymentId)
+    {
+        parent::__construct(sprintf(self::EXCEPTION_MESSAGE, $orderPaymentStatus, $paymentStatus,$paymentId));
+    }
+}

--- a/Model/PaymentStatusHistory.php
+++ b/Model/PaymentStatusHistory.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface;
+
+class PaymentStatusHistory extends AbstractModel implements PaymentStatusHistoryInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function _construct()
+    {
+        $this->_init(\Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getId()
+    {
+        return $this->getData(self::ENTITY_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setId($id)
+    {
+        return $this->setData(self::ENTITY_ID, $id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPaymentId()
+    {
+        return $this->getData(self::PAYMENT_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setPaymentId($paymentId)
+    {
+        return $this->setData(self::PAYMENT_ID, $paymentId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getExternalId()
+    {
+        return $this->getData(self::EXTERNAL_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setExternalId($externalId)
+    {
+        return $this->setData(self::EXTERNAL_ID, $externalId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus()
+    {
+        return $this->getData(self::STATUS);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStatus($status)
+    {
+        return $this->setData(self::STATUS, $status);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCreatedAt()
+    {
+        return $this->getData(self::CREATED_AT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setCreatedAt($createdAt)
+    {
+        return $this->setData(self::CREATED_AT, $createdAt);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getOrderId()
+    {
+        return $this->getData(self::ORDER_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setOrderId($orderId)
+    {
+        return $this->setData(self::ORDER_ID, $orderId);
+    }
+}
+

--- a/Model/PaymentStatusHistoryRepository.php
+++ b/Model/PaymentStatusHistoryRepository.php
@@ -152,8 +152,7 @@ class PaymentStatusHistoryRepository implements PaymentStatusHistoryRepositoryIn
     {
         $paymentHistoryCollection = $this->PaymentStatusHistoryCollectionFactory->create(
             $paymentId,
-            $externalId,
-            true
+            $externalId
         );
         return $paymentHistoryCollection->getFirstItem();
     }

--- a/Model/PaymentStatusHistoryRepository.php
+++ b/Model/PaymentStatusHistoryRepository.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model;
+
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface;
+use Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterfaceFactory;
+use Paynow\PaymentGateway\Api\Data\PaymentStatusHistorySearchResultsInterfaceFactory;
+use Paynow\PaymentGateway\Api\PaymentStatusHistoryRepositoryInterface;
+use Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory as ResourcePaymentStatusHistory;
+use Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory\CollectionFactory as PaymentStatusHistoryCollectionFactory;
+
+class PaymentStatusHistoryRepository implements PaymentStatusHistoryRepositoryInterface
+{
+
+    /**
+     * @var PaymentStatusHistoryCollectionFactory
+     */
+    protected $PaymentStatusHistoryCollectionFactory;
+
+    /**
+     * @var PaymentStatusHistoryInterfaceFactory
+     */
+    protected $PaymentStatusHistoryFactory;
+
+    /**
+     * @var PaymentStatusHistory
+     */
+    protected $searchResultsFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    protected $collectionProcessor;
+
+    /**
+     * @var ResourcePaymentStatusHistory
+     */
+    protected $resource;
+
+    /**
+     * @param ResourcePaymentStatusHistory                      $resource
+     * @param PaymentStatusHistoryInterfaceFactory              $PaymentStatusHistoryFactory
+     * @param PaymentStatusHistoryCollectionFactory             $PaymentStatusHistoryCollectionFactory
+     * @param PaymentStatusHistorySearchResultsInterfaceFactory $searchResultsFactory
+     * @param CollectionProcessorInterface                            $collectionProcessor
+     */
+    public function __construct(
+        ResourcePaymentStatusHistory                      $resource,
+        PaymentStatusHistoryInterfaceFactory              $PaymentStatusHistoryFactory,
+        PaymentStatusHistoryCollectionFactory             $PaymentStatusHistoryCollectionFactory,
+        PaymentStatusHistorySearchResultsInterfaceFactory $searchResultsFactory,
+        CollectionProcessorInterface                            $collectionProcessor
+    ) {
+        $this->resource                                    = $resource;
+        $this->PaymentStatusHistoryFactory           = $PaymentStatusHistoryFactory;
+        $this->PaymentStatusHistoryCollectionFactory = $PaymentStatusHistoryCollectionFactory;
+        $this->searchResultsFactory                        = $searchResultsFactory;
+        $this->collectionProcessor                         = $collectionProcessor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(
+        PaymentStatusHistoryInterface $PaymentStatusHistory
+    ) {
+        try {
+            $this->resource->save($PaymentStatusHistory);
+        } catch (\Exception $exception) {
+            throw new CouldNotSaveException(
+                __(
+                    'Could not save the PaymentStatusHistory: %1',
+                    $exception->getMessage()
+                )
+            );
+        }
+        return $PaymentStatusHistory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        $PaymentStatusHistory = $this->PaymentStatusHistoryFactory->create();
+        $this->resource->load($PaymentStatusHistory, $id);
+        if (!$PaymentStatusHistory->getId()) {
+            throw new NoSuchEntityException(
+                __('PaymentStatusHistory with id "%1" does not exist.', $id)
+            );
+        }
+        return $PaymentStatusHistory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(
+        \Magento\Framework\Api\SearchCriteriaInterface $criteria
+    ) {
+        $collection = $this->PaymentStatusHistoryCollectionFactory->create();
+
+        $this->collectionProcessor->process($criteria, $collection);
+
+        $searchResults = $this->searchResultsFactory->create();
+        $searchResults->setSearchCriteria($criteria);
+
+        $items = [];
+        foreach ($collection as $model) {
+            $items[] = $model;
+        }
+
+        $searchResults->setItems($items);
+        $searchResults->setTotalCount($collection->getSize());
+        return $searchResults;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(
+        PaymentStatusHistoryInterface $PaymentStatusHistory
+    ) {
+        try {
+            $PaymentStatusHistoryModel = $this->PaymentStatusHistoryFactory->create();
+            $this->resource->load(
+                $PaymentStatusHistoryModel,
+                $PaymentStatusHistory->getId()
+            );
+            $this->resource->delete($PaymentStatusHistoryModel);
+        } catch (\Exception $exception) {
+            throw new CouldNotDeleteException(
+                __(
+                    'Could not delete the PaymentStatusHistory: %1',
+                    $exception->getMessage()
+                )
+            );
+        }
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLastByExternalIdAndPaymentId($externalId, $paymentId)
+    {
+        $paymentHistoryCollection = $this->PaymentStatusHistoryCollectionFactory->create(
+            $paymentId,
+            $externalId,
+            true
+        );
+        return $paymentHistoryCollection->getFirstItem();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteById($id)
+    {
+        return $this->delete($this->get($id));
+    }
+}
+

--- a/Model/ResourceModel/PaymentStatusHistory.php
+++ b/Model/ResourceModel/PaymentStatusHistory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class PaymentStatusHistory extends AbstractDb
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init('paynow_paymentgateway_paymentstatushistory', 'entity_id');
+    }
+}
+

--- a/Model/ResourceModel/PaymentStatusHistory/Collection.php
+++ b/Model/ResourceModel/PaymentStatusHistory/Collection.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+class Collection extends AbstractCollection
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected $_idFieldName = 'entity_id';
+
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            \Paynow\PaymentGateway\Model\PaymentStatusHistory::class,
+            \Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory::class
+        );
+    }
+}
+

--- a/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
+++ b/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
@@ -52,7 +52,7 @@ class CollectionFactory implements CollectionFactoryInterface
             $collection->addFieldToFilter('external_id', $externalId);
         }
 
-        $collection->addFieldToSort('created_at', 'DESC');
+        $collection->setOrder('created_at', 'DESC');
 
         return $collection;
     }

--- a/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
+++ b/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
@@ -52,7 +52,7 @@ class CollectionFactory implements CollectionFactoryInterface
             $collection->addFieldToFilter('external_id', $externalId);
         }
 
-        $collection->addAttributeToSort('created_at', 'DESC');
+        $collection->addFieldToSort('created_at', 'DESC');
 
         return $collection;
     }

--- a/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
+++ b/Model/ResourceModel/PaymentStatusHistory/CollectionFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory;
+
+class CollectionFactory implements CollectionFactoryInterface
+{
+
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager = null;
+
+    /**
+     * Instance name to create
+     *
+     * @var string
+     */
+    private $instanceName = null;
+
+    /**
+     * Factory constructor
+     *
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param string                                    $instanceName
+     */
+    public function __construct
+    (
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = \Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory\Collection::class
+    ) {
+        $this->objectManager = $objectManager;
+        $this->instanceName  = $instanceName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $paymentId = null, string $externalId = null)
+    {
+        /** @var \Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory\Collection $collection */
+        $collection = $this->objectManager->create($this->instanceName);
+
+        if ($paymentId) {
+            $collection->addFieldToFilter('payment_id', $paymentId);
+        }
+
+        if ($externalId) {
+            $collection->addFieldToFilter('external_id', $externalId);
+        }
+
+        $collection->addAttributeToSort('created_at', 'DESC');
+
+        return $collection;
+    }
+}

--- a/Model/ResourceModel/PaymentStatusHistory/CollectionFactoryInterface.php
+++ b/Model/ResourceModel/PaymentStatusHistory/CollectionFactoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory;
+
+interface CollectionFactoryInterface
+{
+    /**
+     * Create class instance
+     *
+     * @return \Paynow\PaymentGateway\Model\ResourceModel\PaymentStatusHistory\Collection
+     */
+    public function create(
+        string $paymentId = null,
+        string $externalId = null
+    );
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "pay-now/paynow-magento2",
   "description": "Module for Paynow payments",
   "type": "magento2-module",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "keywords": [
     "paynow",

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="paynow_paymentgateway_paymentstatushistory" resource="default" engine="innodb"
+           comment="paynow_paymentgateway_paymentstatushistory Table">
+        <column xsi:type="int" name="entity_id" padding="10" unsigned="true" nullable="false"
+                identity="true" comment="Entity Id"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="entity_id"/>
+        </constraint>
+        <column name="payment_id" nullable="true" xsi:type="text" comment="payment_id"/>
+        <column name="external_id" nullable="true" xsi:type="text" comment="external_id"/>
+        <column name="order_id" nullable="true" xsi:type="text" comment="order_id"/>
+        <column name="status" nullable="true" xsi:type="text" comment="status"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false"
+                default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+    </table>
+</schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -159,4 +159,9 @@
             <argument name="messageMapping" xsi:type="object">Paynow\PaymentGateway\Gateway\ErrorMapper\VirtualMappingData</argument>
         </arguments>
     </virtualType>
+
+    <!-- Payment status history interfaces binding  -->
+    <preference for="Paynow\PaymentGateway\Api\PaymentStatusHistoryRepositoryInterface" type="Paynow\PaymentGateway\Model\PaymentStatusHistoryRepository"/>
+    <preference for="Paynow\PaymentGateway\Api\Data\PaymentStatusHistoryInterface" type="Paynow\PaymentGateway\Model\PaymentStatusHistory"/>
+    <preference for="Paynow\PaymentGateway\Api\Data\PaymentStatusHistorySearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Paynow_PaymentGateway" setup_version="1.2.1">
+    <module name="Paynow_PaymentGateway" setup_version="1.2.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
W ramach pluginu został dodany dodatkowy model danych, który agreguje historie statusów utrzymując kontekst paymentId oraz externalId. Dzięki temu w procesorze notyfikacji zostało dodane dodatkowe sprawdzenie poprawności zmiany statusów, biorące pod uwagę poprzednie. Zmiana jest kompatybilna wstecznie (dla zamówień, które nie mają historii statusów).